### PR TITLE
Fire marketing click and impression events

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -24,20 +24,18 @@
     <li>
       <a href="index.html">Home</a>
       <a href="page_1.html">Internal page</a>
-      <marketing-element name="cta_1" utm-content="buffercf3b2" utm-medium="social" utm-source="snapchat.com" utm-campaign="buffer">
-        <a href="https://www.google.com" data-search-parameters="itterm, utm-campaign, utm-source, utm-medium">External page</a>
-      </marketing-element>
+      <a href="https://www.google.com">External page</a>
     </li>
   </ul>
-  <marketing-element name="cta_1" data-click-schema="marketing_event_1" data-impression-schema="marketing_event_1">
-    <h4>I'm just a marketing element</h4>
-  </marketing-element>
   <web-app></web-app>
   <div style="height:100vh;background-color:gray;">&nbsp;</div>
+  <!--
   <marketing-element name="cta_footer" capture-clicks utm-content="buffercf3b2" utm-medium="social"
     utm-source="snapchat.com" utm-campaign="buffer">
     <a href="https://www.google.com" data-search-parameters="utm-medium">External page</a>
   </marketing-element>
+  -->
+  <a href="https://www.google.com" data-marketing-name="footer-cta" forward-search-params trackable>External page</a>
   <script type="text/javascript" src="scripts/bundle.js" type="module"></script>
 </body>
 

--- a/assets/index.html
+++ b/assets/index.html
@@ -1,34 +1,44 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes"
-    />
-    <title>Marketing Parameter Forwarder</title>
-    <meta name="description" content="Marketing Parameter Forwarder" />
-    <!-- Add any global styles for body, document, etc. -->
-    <style>
-      body {
-        font-family: var(--theme-font-family, 'Segoe UI',Arial, sans-serif);
-      }
-    </style>
-    <script>window.process = {env: {NODE_ENV: 'development'} };</script>
-  </head>
-  <body>
-    <noscript>
-      Please enable JavaScript to view this website.
-    </noscript>
-    <h1>Marketing Parameter Forwarder</h1>
-    <ul>
-      <li>
-        <a href="index.html">Home</a>
-        <a href="page_1.html">Internal page</a>
-        <a href="https://www.google.com" data-forward-utms>External page</a>
-      </li>
-    </ul>
-    <web-app></web-app>
-    <script type="text/javascript" src="scripts/bundle.js" type="module"></script>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes" />
+  <title>Marketing Parameter Forwarder</title>
+  <meta name="description" content="Marketing Parameter Forwarder" />
+  <!-- Add any global styles for body, document, etc. -->
+  <style>
+    body {
+      font-family: var(--theme-font-family, 'Segoe UI', Arial, sans-serif);
+    }
+  </style>
+  <script>window.process = { env: { NODE_ENV: 'development' } };</script>
+</head>
+
+<body>
+  <noscript>
+    Please enable JavaScript to view this website.
+  </noscript>
+  <h1>Marketing Parameter Forwarder</h1>
+  <ul>
+    <li>
+      <a href="index.html">Home</a>
+      <a href="page_1.html">Internal page</a>
+      <marketing-element name="cta_1" utm-content="buffercf3b2" utm-medium="social" utm-source="snapchat.com" utm-campaign="buffer">
+        <a href="https://www.google.com" data-search-parameters="itterm, utm-campaign, utm-source, utm-medium">External page</a>
+      </marketing-element>
+    </li>
+  </ul>
+  <marketing-element name="cta_1" data-click-schema="marketing_event_1" data-impression-schema="marketing_event_1">
+    <h4>I'm just a marketing element</h4>
+  </marketing-element>
+  <web-app></web-app>
+  <div style="height:100vh;background-color:gray;">&nbsp;</div>
+  <marketing-element name="cta_footer" capture-clicks utm-content="buffercf3b2" utm-medium="social"
+    utm-source="snapchat.com" utm-campaign="buffer">
+    <a href="https://www.google.com" data-search-parameters="utm-medium">External page</a>
+  </marketing-element>
+  <script type="text/javascript" src="scripts/bundle.js" type="module"></script>
+</body>
+
 </html>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -31,8 +31,12 @@ export class App {
       (cookieData: string) => document.cookie = cookieData,
       document.cookie,
       document.body,
-      'data-forward-utms',
       this.eligibleParameters,
+      (ev: MouseEvent) => {
+        const t: Element = ev.target as Element;
+        alert(`Log click on marketing element [${t.getAttribute('data-marketing-name')}]`);
+      },
+      (target: Element) => console.log(`Log impression on marketing element [${target.getAttribute('data-marketing-name')}]`),
     );
   }
 

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -1,4 +1,5 @@
 'use strict';
 
+export { MarketingElement } from './marketingElement';
 export { SampleWebComponent } from './sampleWebComponent';
 export { WebApp } from './webApp';

--- a/src/web/marketingElement.ts
+++ b/src/web/marketingElement.ts
@@ -1,0 +1,106 @@
+'use strict';
+
+export class MarketingElement extends HTMLElement {
+  private intersectionObserver: IntersectionObserver;
+
+  public static get is(): string {
+    return 'marketing-element';
+  }
+
+  public static get marketingAttributes(): string[] {
+    return [
+      'itcat',
+      'itterm',
+      'utm-campaign',
+      'utm-content',
+      'utm-medium',
+      'utm-source',
+      'utm-term',
+    ];
+  }
+
+  public static get observedAttributes(): string[] {
+    return [...MarketingElement.marketingAttributes];
+  }
+
+  public constructor() {
+    super();
+  }
+
+  public connectedCallback() {
+    this.addEventListener('click', this.handleClick);
+
+    this.intersectionObserver = new IntersectionObserver(
+      (entries: IntersectionObserverEntry[]) => this.handleImpression(entries),
+      {
+        root: null,
+        rootMargin: '0px',
+        threshold: 1.0,
+      },
+    );
+    
+    this.intersectionObserver.observe(this);
+  }
+
+  public disconnectedCallback() {
+    this.removeEventListener('click', this.handleClick);
+    this.intersectionObserver.unobserve(this);
+  }
+
+  public handleClick(e: MouseEvent) {
+    if (!this.hasAttribute('capture-clicks')) {
+      return;
+    }
+    
+    alert(`Logging click event [${this.getAttribute('name')}]`);
+  }
+
+  public handleImpression(entries: IntersectionObserverEntry[]) {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        const schema = this.getAttribute('data-impression-schema');
+        console.log(`Logging impression event [${this.getAttribute('name')}]`);
+        this.intersectionObserver.unobserve(this);
+      }
+    });
+  }
+
+  public attributeChangedCallback(
+    name: string,
+    oldValue: string,
+    newValue: string,
+    namespace: string,
+  ): void {
+    if (oldValue === newValue) {
+      return;
+    }
+
+    if (MarketingElement.marketingAttributes.includes(name)) {
+      this.updateSearchParameter(name, newValue);
+    }
+  }
+
+  private updateSearchParameter(key: string, value?: string): void {
+    this
+      .querySelectorAll('a[data-search-parameters]')
+      .forEach((a: HTMLAnchorElement) => this.updateAnchor(a, key, value));
+  }
+
+  private updateAnchor(anchor: HTMLAnchorElement, key, value): void {
+    const url = new URL(anchor.href);
+    const anchorParameters = anchor.getAttribute('data-search-parameters').replace(/\s/g, '').split(',');
+    const addAll = anchorParameters.length === 0;
+
+    if (addAll || anchorParameters.includes(key)) {
+      if (value) {
+        url.searchParams.set(key, value.toString());
+      } else {
+        url.searchParams.delete(key);
+      }
+    }
+
+    anchor.search = url.search;
+  }
+}
+
+window.customElements.define(MarketingElement.is, MarketingElement);

--- a/src/web/sampleWebComponent.ts
+++ b/src/web/sampleWebComponent.ts
@@ -1,15 +1,15 @@
 'use strict';
 
 export class SampleWebComponent extends HTMLElement {
-    public static get is(): string { 
-        return 'sample-web-component';
-    }
+  public static get is(): string {
+    return 'sample-web-component';
+  }
 
-    public static get observedAttributes(): string[] {
-        return['message'];
-    }
+  public static get observedAttributes(): string[] {
+    return ['message'];
+  }
 
-    private template: string = `
+  private template: string = `
         <style>
             :host {
                 display: block;
@@ -18,31 +18,31 @@ export class SampleWebComponent extends HTMLElement {
         <h3 bind-to="message">...</h3>
     `;
 
-    private messageElement: HTMLElement;
+  private messageElement: HTMLElement;
 
-    public constructor() {
-        super();
+  public constructor() {
+    super();
 
-        const shadowRoot: ShadowRoot = this.attachShadow({mode: 'open'});
-        shadowRoot.innerHTML = this.template;
-        this.messageElement = shadowRoot.querySelector('[bind-to=message]');
+    const shadowRoot: ShadowRoot = this.attachShadow({ mode: 'open' });
+    shadowRoot.innerHTML = this.template;
+    this.messageElement = shadowRoot.querySelector('[bind-to=message]');
+  }
+
+  public attributeChangedCallback(
+    name: string,
+    oldValue: string,
+    newValue: string,
+    namespace: string,
+  ): void {
+    if (oldValue === newValue) {
+      return;
     }
 
-    public attributeChangedCallback(
-        name: string,
-        oldValue: string,
-        newValue: string,
-        namespace: string,
-      ): void {
-          if (oldValue === newValue) {
-              return;
-          }
-
-          if (name === 'message') {
-            this.messageElement.textContent = newValue;
-            return;
-          }
-      }
+    if (name === 'message') {
+      this.messageElement.textContent = newValue;
+      return;
+    }
+  }
 }
 
 window.customElements.define(SampleWebComponent.is, SampleWebComponent);


### PR DESCRIPTION
Closes #2 

Implements the functionality for the following user stories:

**User story**
As a marketing specialist,
when analyzing the visitor journeys,
I want to have access to impression and click data
so I can determine what elements of a page need to receive attribution weight.

**Business logic:**
1. When a page on the site loads, the system checks if we are coming from an external source
   1. If we are coming from an external page, the system updates the marketing cookies
      1. The system retrieves the white listed parameters from the query string
      2. The system ensures parameters have been cleaned up to protect against script injections
      3. The system sets the marketing cookies
      4. The system retrieves the marketing parameters from the URL
   1, If we are coming from an internal page
      1. The system retrieves the marketing parameters from the existing cookie
2. The system updates the marketing assets by
   1. Appending the marketing search parameters to the search string of marked links
   2. Adding click and impression events to all marketing elements